### PR TITLE
Fix the tipping bug.

### DIFF
--- a/command0_1.php
+++ b/command0_1.php
@@ -226,6 +226,11 @@ class CommandHandler {
             
             deductFunds($account_assoc, $total_sent + $charged);
             
+            // Messy fallback to fix the tipping bug.
+            if ($list_len == -1) {
+                addFunds($to_address, abs((int) $uSats));
+            }
+            
             for ($i = 0; $i < $list_len; $i++) {
                 if (gettype($to_address) == "array") {
                     $this_to_address = $to_address[$i];


### PR DESCRIPTION
Basicly, the new batch command processing code was set up to iterate through the tips and add balances to each one. It did this with a 'for' loop, but as 'list_len' is -1 for single commands, the loop never gets run. I've put in a work around so that if 'list_len' equals -1 it runs anyway.
